### PR TITLE
feature: allow cli params for directory and port

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "autoprefixer": "^10.2.5",
         "chalk": "^5.0.0",
         "chokidar": "^3.5.1",
-        "command-line-args": "^5.2.1",
         "escodegen": "^2.0.0",
         "html-escaper": "^3.0.3",
         "koa": "^2.13.1",
@@ -75,14 +74,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
       "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
-    },
-    "node_modules/array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.2",
@@ -238,20 +229,6 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/command-line-args": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
-      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
-      "dependencies": {
-        "array-back": "^3.1.0",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/concat-map": {
@@ -457,17 +434,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "dependencies": {
-        "array-back": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/fraction.js": {
@@ -757,11 +723,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "node_modules/marked": {
       "version": "4.0.10",
@@ -1245,14 +1206,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1320,11 +1273,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
       "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
-    },
-    "array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
     },
     "autoprefixer": {
       "version": "10.4.2",
@@ -1421,17 +1369,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
-    "command-line-args": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
-      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
-      "requires": {
-        "array-back": "^3.1.0",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1579,14 +1516,6 @@
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "requires": {
         "to-regex-range": "^5.0.1"
-      }
-    },
-    "find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "requires": {
-        "array-back": "^3.0.1"
       }
     },
     "fraction.js": {
@@ -1797,11 +1726,6 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "marked": {
       "version": "4.0.10",
@@ -2149,11 +2073,6 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
-    },
-    "typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "substrate",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "substrate",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.2.1",
         "autoprefixer": "^10.2.5",
         "chalk": "^5.0.0",
         "chokidar": "^3.5.1",
+        "command-line-args": "^5.2.1",
         "escodegen": "^2.0.0",
         "html-escaper": "^3.0.3",
         "koa": "^2.13.1",
@@ -74,6 +75,14 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
       "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.2",
@@ -229,6 +238,20 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/concat-map": {
@@ -434,6 +457,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/fraction.js": {
@@ -723,6 +757,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "node_modules/marked": {
       "version": "4.0.10",
@@ -1206,6 +1245,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1273,6 +1320,11 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
       "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
+    },
+    "array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
     },
     "autoprefixer": {
       "version": "10.4.2",
@@ -1369,6 +1421,17 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "requires": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1516,6 +1579,14 @@
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "requires": {
         "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "requires": {
+        "array-back": "^3.0.1"
       }
     },
     "fraction.js": {
@@ -1726,6 +1797,11 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "marked": {
       "version": "4.0.10",
@@ -2073,6 +2149,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "autoprefixer": "^10.2.5",
     "chalk": "^5.0.0",
     "chokidar": "^3.5.1",
+    "command-line-args": "^5.2.1",
     "escodegen": "^2.0.0",
     "html-escaper": "^3.0.3",
     "koa": "^2.13.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "autoprefixer": "^10.2.5",
     "chalk": "^5.0.0",
     "chokidar": "^3.5.1",
-    "command-line-args": "^5.2.1",
     "escodegen": "^2.0.0",
     "html-escaper": "^3.0.3",
     "koa": "^2.13.1",

--- a/server.js
+++ b/server.js
@@ -21,8 +21,6 @@ let cmdSettings, initialPath, args;
 
 console.log('\n')
 
-console.log('process argv ', process.argv)
-
 // configure port and path from command line arguments
 // useable from cli as 
 //      --directory || -d

--- a/server.js
+++ b/server.js
@@ -15,9 +15,13 @@ import { dirname, relative, resolve, sep } from 'path'
 import commandLineArgs      from 'command-line-args';
 
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = dirname(fileURLToPath(import.meta.url));
+let cmdSettings, initialPath, args;
+
 
 console.log('\n')
+
+console.log('process argv ', process.argv)
 
 // configure port and path from command line arguments
 // useable from cli as 
@@ -28,8 +32,16 @@ const cmdOptions = [
     { name: 'port', alias: 'p', defaultValue: 5000, type: Number}
 ];
 
-const cmdSettings = commandLineArgs(cmdOptions);
-const servePath = resolve(cmdSettings.directory);
+// backward compatibility for running root>node substrate <directory>
+if (process.argv.length === 3) {
+    args = process.argv.slice(2);
+} else {
+    cmdSettings = commandLineArgs(cmdOptions);
+}
+
+initialPath = !cmdSettings ? args.shift() || '' : cmdSettings.directory;
+const servePath = resolve(initialPath);
+
 
 if (!fs.existsSync(servePath)) {
     console.error(`${chalk.red('Error!')} The input path ${chalk.redBright(servePath)} does not exist.`)
@@ -246,7 +258,7 @@ app.use(async (ctx, next) => {
 
 app.use(serve(servePath))
 
-const PORT = cmdSettings.port;
+const PORT = cmdSettings?.port || 5000;
  
 app.listen(PORT)
  

--- a/server.js
+++ b/server.js
@@ -12,34 +12,31 @@ import Koa                  from 'koa'
 import { PassThrough }      from 'stream'
 import { fileURLToPath }    from 'url'
 import { dirname, relative, resolve, sep } from 'path'
-import commandLineArgs      from 'command-line-args';
 
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-let cmdSettings, initialPath, args;
-
+let args, initialPath = '', port = 5000;
 
 console.log('\n')
 
-// configure port and path from command line arguments
-// useable from cli as 
-//      --directory || -d
-//      --port      || -p
-const cmdOptions = [
-    { name: 'directory', alias: 'd', defaultValue: '', type: String },
-    { name: 'port', alias: 'p', defaultValue: 5000, type: Number }
-];
+const setVars = (val) => {
+    if (!val)
+        return;
+    
+    if (Number(val)) {
+        port = val;
+    } else {
+        initialPath = val;
+    }
+};
 
-// backward compatibility for 
-//  substrate <directory>
-//  root>node server.js <directory>
-if (process.argv.length === 3) {
-    args = process.argv.slice(2);
-} else {
-    cmdSettings = commandLineArgs(cmdOptions);
-}
+// there is no guarantee that the user sent the cmd line args in the correct order
+// we are expecting <directory> <port> but it could be in any order
+// both <directory> and <port> are optional so either could be missing
+args = process.argv.slice(2, process.argv.length);
+setVars(args[0]);
+setVars(args[1]);
 
-initialPath = !cmdSettings ? args.shift() || '' : cmdSettings.directory;
 const servePath = resolve(initialPath);
 
 
@@ -258,7 +255,7 @@ app.use(async (ctx, next) => {
 
 app.use(serve(servePath))
 
-const PORT = cmdSettings?.port || 5000;
+const PORT = port;
  
 app.listen(PORT)
  

--- a/server.js
+++ b/server.js
@@ -12,16 +12,24 @@ import Koa                  from 'koa'
 import { PassThrough }      from 'stream'
 import { fileURLToPath }    from 'url'
 import { dirname, relative, resolve, sep } from 'path'
+import commandLineArgs      from 'command-line-args';
 
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 console.log('\n')
 
-// parse the path from the command line argument
-const args = process.argv.slice(2)
-const initialPath = args.shift() || ''
-const servePath = resolve(initialPath)
+// configure port and path from command line arguments
+// useable from cli as 
+//      --directory || -d
+//      --port      || -p
+const cmdOptions = [
+    { name: 'directory', alias: 'd', defaultValue: '', type: String },
+    { name: 'port', alias: 'p', defaultValue: 5000, type: Number}
+];
+
+const cmdSettings = commandLineArgs(cmdOptions);
+const servePath = resolve(cmdSettings.directory);
 
 if (!fs.existsSync(servePath)) {
     console.error(`${chalk.red('Error!')} The input path ${chalk.redBright(servePath)} does not exist.`)
@@ -238,8 +246,8 @@ app.use(async (ctx, next) => {
 
 app.use(serve(servePath))
 
-const PORT = 5000
+const PORT = cmdSettings.port;
  
-app.listen(5000)
+app.listen(PORT)
  
-console.log(`Substrate server listening on port ${PORT}`)
+console.log(`Substrate server listening on port ${PORT}`);

--- a/server.js
+++ b/server.js
@@ -27,10 +27,12 @@ console.log('\n')
 //      --port      || -p
 const cmdOptions = [
     { name: 'directory', alias: 'd', defaultValue: '', type: String },
-    { name: 'port', alias: 'p', defaultValue: 5000, type: Number}
+    { name: 'port', alias: 'p', defaultValue: 5000, type: Number }
 ];
 
-// backward compatibility for running root>node substrate <directory>
+// backward compatibility for 
+//  substrate <directory>
+//  root>node server.js <directory>
 if (process.argv.length === 3) {
     args = process.argv.slice(2);
 } else {


### PR DESCRIPTION
https://developer.apple.com/forums/thread/682332
Allow cli params for directory and port because Mac Control Center listens to port 5000 on macOS Monterey.  Port 5000 was the hardcoded port used by the substrate server and will continue to be the default if no port is provided by the user.